### PR TITLE
can set other options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,13 +13,18 @@ inputs:
     description: 'alert level (INFO, WARN, FATAL)'
     required: false
     default: 'WARN'
+  others:
+    description: 'other options example: -i DKL-DI-0001'
+    required: false
+    default: '--ignore=""' # need to any options
 runs:
   using: 'docker'
   image: 'docker://goodwithtech/dockle:latest'
   args:
     - '--exit-code=${{ inputs.exit-code }}'
     - '--exit-level=${{ inputs.exit-level }}'
-    - '${{ inputs.image }}'
+    - '${{ inputs.others}}'
+    - ${{ inputs.image }}
 branding:
   icon: 'search'
   color: 'green'


### PR DESCRIPTION
こんにちは！日々便利に利用させて頂いています！
[DKL-DI-0005](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#DKL-DI-0005)が親のイメージまで見てしまい、自動テストが落ちて不便なケースがあるため、ignoreを入れたいのですが、igrenoreの指定が複数の場合、`-i xxxx -i xxx` なので自由入力項目のほうが都合が良いので `others` オプションを追加しました。
マージの検討をいただけると嬉しいです。

Hi Team!
It is very useful actions.
[DKL-DI-0005](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#DKL-DI-0005) is to check parent image and occur error when auto test threfore I want to  add `ignore` option.
However, `ignogre` options can't use Array thus `others` options.
It is can defined free text options.
thanks.
 